### PR TITLE
Remove edit confirmation, selector clear, clear front/back on save

### DIFF
--- a/src/pages/Selector/index.js
+++ b/src/pages/Selector/index.js
@@ -1,6 +1,6 @@
 import ClickList from '../../components/ClickList'
 import SearchIcon from '@mui/icons-material/Search';
-import { Box, TextField, InputAdornment, Typography, ListItem } from "@mui/material";
+import { Box, TextField, InputAdornment, Typography, ListItem, Button } from "@mui/material";
 import { useCards } from '../../state/CardProvider.js'
 import { useState, useEffect } from 'react'
 import { useTheme } from "@mui/material/styles";
@@ -36,7 +36,11 @@ const Selector = ({onAdd, onRemove, tags}) => {
 	}
 
 	const handleRemove = (index) => {
-		onRemove(tags[index])
+		onRemove([tags[index]])
+	}
+
+	const handleClear = () => {
+		onRemove(tags)
 	}
 
 	const ListTagSx = (color) => ({
@@ -112,7 +116,7 @@ const Selector = ({onAdd, onRemove, tags}) => {
 						display: 'flex',
 						flexDirection: 'column',
 						height: '100%' }}>
-				<Box sx={{ display: 'flex' }}>
+					<Box sx={{ display: 'flex'}}>
 					<TextField
 						placeholder='Filter...'
 						value={inputValue}
@@ -132,7 +136,17 @@ const Selector = ({onAdd, onRemove, tags}) => {
 							width: '50%',
 						}}
 					/>
-					<Box sx={{ width: '50%' }} />
+			<Box sx={{ width: '50%', }} >
+						<Button
+							size="small"
+							variant="standard"
+							sx={{ fontSize: '0.65rem', width: '90%', color: '#800000', "&:hover": { textDecoration: 'underline'} }}
+							disableRipple
+							onClick={() => handleClear()}
+							>
+							Clear
+						</Button>
+					</Box>
 				</Box>
 				<Box sx={{ display: 'flex', overflowY: 'auto' }} >
 					<Box sx={{ overflowY: 'auto', height: '98%', width:'50%', }}>

--- a/src/pages/editCard.js
+++ b/src/pages/editCard.js
@@ -1,6 +1,5 @@
 import { useState, useEffect, } from 'react'
 import DefaultPopup from '../components/Popup'
-import ConfirmationPopup from './confirmPopup'
 import Selector from './Selector'
 import { useCards } from '../state/CardProvider.js'
 import { Button, TextField, Typography, Box } from '@mui/material';
@@ -8,7 +7,6 @@ import { useTheme } from "@mui/material/styles";
 
 const EditCard = ({popupState, card}) => {
 	const {open, setOpen} = popupState
-	const [copen, setCopen] = useState(false)
 	const theme = useTheme(); 
 
 	const { addCard, editCard } = useCards();
@@ -43,16 +41,13 @@ const EditCard = ({popupState, card}) => {
 				addCard(front, back, cardState.tags)
 			setOpen(false)
 		}
-	};
-	const handleCancelConfirm = () => {
-		setCopen(false)
-		setOpen(false)
+		setCardState({ id: null, front: '', back: '', tags: cardState.tags})
 	};
 
 	return (
 		<DefaultPopup
 			open={open}
-			onClose={(e) => {setCopen(true)}}
+			onClose={(e) => {setOpen(false)}}
 		>
 			<Box
 				sx={{
@@ -118,7 +113,7 @@ const EditCard = ({popupState, card}) => {
 						<Box sx={{ backgroundColor: "#f4f4f4", borderRadius: '8px', height: '100%', }}>
 							<Selector
 								onAdd={(e) => { setCardState((p) => ({ ...p, tags: [...p.tags, e]}))}}
-								onRemove={(e) => { setCardState((p) => ({ ...p, tags: p.tags.filter(tag => tag !== e)}))}}
+								onRemove={(e) => { setCardState((p) => ({ ...p, tags: p.tags.filter(tag => !e.includes(tag))}))}}
 								tags={cardState.tags}
 							/>
 						</Box>
@@ -126,14 +121,9 @@ const EditCard = ({popupState, card}) => {
 				</Box>
 
 				<Box sx={{ display: 'flex', justifyContent: 'flex-end', alignItems:'center', mt:2}}>
-					<Button disableRipple variant="outlined" onClick={() => setCopen(true)} sx={{fontSize: '0.875rem',padding: '6px 12px', marginRight: '8px', }}> Cancel </Button>
+					<Button disableRipple variant="outlined" onClick={() => setOpen(false)} sx={{fontSize: '0.875rem',padding: '6px 12px', marginRight: '8px', }}> Cancel </Button>
 					<Button disableRipple variant="contained" onClick={() => handleSave()} disabled={!isSaveEnabled} sx={{fontSize: '0.875rem',padding: '6px 12px', marginRight: '8px'}}> Save </Button>
 				</Box>	
-				<ConfirmationPopup
-					open={copen}
-					onCancel={() => setCopen(false)}
-					onConfirm={() => handleCancelConfirm()}
-					message='Discard Edits?'/>
 			</Box>
         </DefaultPopup>
 	)


### PR DESCRIPTION
- Removed the "Discard Edits?" confirmation when pressing cancel on the add card popup, as edits are not discarded until the page is refreshed (which bypasses the confirmation anyways)
- Cleared the front/back textboxes upon saving a new card
- Did not clear tags automatically---opted to include a "Clear" button in the selector that would remove all tags. I think this approach creates less work for the user when batch adding similar cards